### PR TITLE
fix(login): removed auto-redirect when only 1 provider

### DIFF
--- a/apps/frontend/src/pages/auth/login/index.vue
+++ b/apps/frontend/src/pages/auth/login/index.vue
@@ -51,9 +51,6 @@ const colors: Record<string, string> = {
 const login = useAsyncState(
   async () => {
     const data = await http.get('auth/login').json<{ providers: string[]; signup: boolean }>()
-    if (data.providers.length === 1) {
-      router.push({ path: `/auth/login/${data.providers[0]}`, query: route.query })
-    }
     return data
   },
   {


### PR DESCRIPTION
## Description

当只有一个 login provider 的时候会触发自动跳转，此时无法选中 index 页面的 Signup 按钮。

## Changelog

- 删除了自动跳转